### PR TITLE
feat(r36sx): add physical FN button mapping support

### DIFF
--- a/frogui_libretro.c
+++ b/frogui_libretro.c
@@ -2402,6 +2402,14 @@ static void handle_core_picker(void) {
     }
 }
 
+/* Wizard covers every button except FN, which is only probed on devices that
+ * have the physical button (device detection, see input_fn_available). FN is
+ * the last enum entry, so on FN-less devices the wizard finishes right after
+ * SELECT and never asks for a button that isn't there. */
+static int remap_wizard_count(void) {
+    return FROG_BTN_COUNT - (input_fn_available() ? 0 : 1);
+}
+
 static void handle_remap_wizard(void) {
     uint32_t raw   = input_get_raw_state();
     uint32_t risen = raw & ~remap_prev_raw;
@@ -2416,7 +2424,7 @@ static void handle_remap_wizard(void) {
     if (skip || pressed_bit >= 0) {
         if (!skip) input_set_raw_bit((FrogButton)remap_step, pressed_bit);
         remap_step++;
-        if (remap_step >= FROG_BTN_COUNT) {
+        if (remap_step >= remap_wizard_count()) {
             remap_wizard_active = false;
             input_save_remap(KEYMAP_FILE);
             ui_toast_show("Button mapping saved");
@@ -3473,7 +3481,7 @@ static void render_remap_wizard(void) {
 
     char line[128];
     int y = START_Y;
-    snprintf(line, sizeof(line), "Press  %s  (%d / %d)", input_btn_name((FrogButton)remap_step), remap_step + 1, FROG_BTN_COUNT);
+    snprintf(line, sizeof(line), "Press  %s  (%d / %d)", input_btn_name((FrogButton)remap_step), remap_step + 1, remap_wizard_count());
     font_draw_text(framebuffer, SCREEN_WIDTH, SCREEN_HEIGHT, PADDING, y, line, COLOR_TEXT);
 
     y += ITEM_HEIGHT;

--- a/frogui_libretro.c
+++ b/frogui_libretro.c
@@ -2409,7 +2409,7 @@ static void handle_remap_wizard(void) {
     bool skip = (risen >> input_get_raw_bit(FROG_BTN_B)) & 1;
     int  pressed_bit = -1;
     if (!skip) {
-        for (int bit = 0; bit < 16; bit++) {
+        for (int bit = 0; bit < FROG_RAW_BIT_COUNT; bit++) {
             if ((risen >> bit) & 1) { pressed_bit = bit; break; }
         }
     }

--- a/input.c
+++ b/input.c
@@ -35,6 +35,7 @@ static const int default_bits[FROG_BTN_COUNT] = {
     [FROG_BTN_R2]     = -1,
     [FROG_BTN_START]  = 3,
     [FROG_BTN_SELECT] = 0,
+    [FROG_BTN_FN]     = 16,
 };
 
 static int remap_bits[FROG_BTN_COUNT];
@@ -44,13 +45,13 @@ static uint32_t remap_logical_bits[FROG_BTN_COUNT]; /* precomputed: 1<<logical *
 static void rebuild_masks(void) {
     for (int i = 0; i < FROG_BTN_COUNT; i++) {
         int b = remap_bits[i];
-        remap_raw_masks[i]    = (b >= 0 && b <= 15) ? (1u << b) : 0;
+        remap_raw_masks[i]    = (b >= 0 && b <= FROG_RAW_MAX_BIT) ? (1u << b) : 0;
         remap_logical_bits[i] = 1u << i;
     }
 }
 
 static const char *btn_names[FROG_BTN_COUNT] = {
-    "UP","DOWN","LEFT","RIGHT","A","B","X","Y","L1","R1","L2","R2","START","SELECT"
+    "UP","DOWN","LEFT","RIGHT","A","B","X","Y","L1","R1","L2","R2","START","SELECT","FN"
 };
 
 const char *input_btn_name(FrogButton btn) {
@@ -108,18 +109,18 @@ void input_update(void) {
     /* Combine the raw joy_key shm with ext_raw (picoarch's ALREADY-debounced input
      * via input_state_cb). The shm alone flickers from the rkgame+cubevol two-writer
      * race → ghost menu inputs; ORing+debouncing below removes that. */
-    uint32_t raw = (cubevol_keys ? (*cubevol_keys & 0xFFFF) : 0) | (ext_raw & 0xFFFF);
+    uint32_t raw = (cubevol_keys ? (*cubevol_keys & FROG_RAW_BUTTON_MASK) : 0) | (ext_raw & FROG_RAW_BUTTON_MASK);
 
     /* Debounce face bits by ELAPSED TIME, not update count. The redraw-on-demand
      * UI polls near 1kHz between presented frames, so the old 4-update debounce
      * shrank from its intended ~65ms to ~4ms. That allowed the right stick's
      * merged X-bit glitches to open Search while a game list was scrolling.
      * Navigation stays immediate; release always clears immediately. */
-    static long down_since[16] = {0};
+    static long down_since[FROG_RAW_BIT_COUNT] = {0};
     static uint32_t raw_down = 0;
     static uint32_t committed = 0;
     long now = input_now_ms();
-    for (int b = 0; b < 16; b++) {
+    for (int b = 0; b < FROG_RAW_BIT_COUNT; b++) {
         uint32_t m = 1u << b;
         if (raw & m) {
             if (!(raw_down & m)) {
@@ -173,11 +174,11 @@ bool input_repeat(FrogButton btn) {
     return false;
 }
 
-void input_set_ext_raw(uint32_t raw) { ext_raw = raw; }
+void input_set_ext_raw(uint32_t raw) { ext_raw = raw & FROG_RAW_BUTTON_MASK; }
 
 uint32_t input_get_raw_state(void) {
-    uint32_t shm = cubevol_keys ? (*cubevol_keys & 0xFFFF) : 0;
-    return shm | ext_raw;
+    uint32_t shm = cubevol_keys ? (*cubevol_keys & FROG_RAW_BUTTON_MASK) : 0;
+    return (shm | ext_raw) & FROG_RAW_BUTTON_MASK;
 }
 
 void input_set_raw_bit(FrogButton btn, int raw_bit) {

--- a/input.c
+++ b/input.c
@@ -59,9 +59,59 @@ const char *input_btn_name(FrogButton btn) {
     return btn_names[btn];
 }
 
+/* FN capability — mirrors picoarch's sf3000_fn_capability_init() semantics.
+ * The physical FN button is only confirmed on the R36SX family (raw bit 16);
+ * other devices (SF3000/SF3500/GB350/SF3100/R36HD-class clones) must not get an
+ * FN default mapping nor an FN wizard step, or they would be asked to map a
+ * button they do not have and any unrelated bit 16 signal would be read as FN.
+ * Detection: TF_DEVICE=R36SX from the boot env file zhijack writes
+ * (/tmp/tfdevice.env), falling back to the inherited TF_DEVICE env var.
+ * Overrides (both directions, same as picoarch): SF3000_HAS_FN env var and
+ * /mnt/sdcard/fn_enable flag file. Raw bit 16 itself stays data-driven: if FN
+ * is not mapped, the bit is simply inert. */
+bool input_fn_available(void) {
+    static int available = -1;
+    if (available >= 0) return available != 0;
+
+    int has = 0;
+    const char *tfdev = getenv("TF_DEVICE");
+    if (tfdev && strcmp(tfdev, "R36SX") == 0) has = 1;
+    else {
+        FILE *tf = fopen("/tmp/tfdevice.env", "r");
+        if (tf) {
+            char line[128];
+            while (fgets(line, sizeof line, tf)) {
+                if (strstr(line, "TF_DEVICE=R36SX")) { has = 1; break; }
+            }
+            fclose(tf);
+        }
+    }
+    const char *ev = getenv("SF3000_HAS_FN");
+    if (ev && (ev[0]=='1' || ev[0]=='y' || ev[0]=='Y')) has = 1;
+    else if (ev && (ev[0]=='0' || ev[0]=='n' || ev[0]=='N')) has = 0;
+    FILE *f = fopen("/mnt/sdcard/fn_enable", "r");
+    if (f) {
+        char c;
+        if (fread(&c, 1, 1, f) == 1) {
+            if (c=='1' || c=='y' || c=='Y') has = 1;
+            else if (c=='0' || c=='n' || c=='N') has = 0;
+        }
+        fclose(f);
+    }
+
+    available = has;
+    return has != 0;
+}
+
 void input_reset_defaults(void) {
     for (int i = 0; i < FROG_BTN_COUNT; i++)
         remap_bits[i] = default_bits[i];
+    /* FN defaults to raw bit 16 only on devices that have the button; on
+     * everything else it ships unmapped (-1 = inert). A saved FN=<bit> line is
+     * likewise ignored at load time on FN-less devices (bit 16 there is an
+     * unrelated signal, not FN). */
+    if (!input_fn_available())
+        remap_bits[FROG_BTN_FN] = -1;
     rebuild_masks();
 }
 
@@ -206,6 +256,10 @@ int input_load_remap(const char *path) {
         int val = atoi(eq + 1);
         for (int i = 0; i < FROG_BTN_COUNT; i++) {
             if (strcmp(line, btn_names[i]) == 0) {
+                /* Ignore a saved FN mapping on devices without the button (e.g.
+                 * a keymap written on an R36SX SD reused elsewhere) — bit 16
+                 * there is an unrelated signal, not FN. */
+                if (i == FROG_BTN_FN && !input_fn_available()) break;
                 remap_bits[i] = val;
                 break;
             }

--- a/input.h
+++ b/input.h
@@ -9,6 +9,9 @@
 #include <stdbool.h>
 
 #define KEYMAP_FILE "/mnt/sdcard/frogui/keymap.txt"
+#define FROG_RAW_MAX_BIT 16
+#define FROG_RAW_BIT_COUNT 17
+#define FROG_RAW_BUTTON_MASK 0x0001FFFFu
 
 typedef enum {
     FROG_BTN_UP = 0,
@@ -25,6 +28,7 @@ typedef enum {
     FROG_BTN_R2,
     FROG_BTN_START,
     FROG_BTN_SELECT,
+    FROG_BTN_FN,
     FROG_BTN_COUNT
 } FrogButton;
 
@@ -43,11 +47,11 @@ bool input_is_pressed(FrogButton btn);
 bool input_was_pressed(FrogButton btn);   /* true only on rising edge this frame */
 bool input_repeat(FrogButton btn);        /* edge, then auto-repeats while held (time-based) */
 
-/* Raw 16-bit cubevol value (needed by remap wizard). */
+/* Raw cubevol value (bits 0..16 inclusive, mask 0x1FFFF) needed by remap wizard. (needed by remap wizard). */
 uint32_t input_get_raw_state(void);
 void input_set_ext_raw(uint32_t raw);
 
-/* Remap table: logical button -> raw bit index (0-15), or -1 = unmapped. */
+/* Remap table: logical button -> raw bit index (0..16), or -1 = unmapped. */
 void input_reset_defaults(void);
 void input_set_raw_bit(FrogButton btn, int raw_bit);
 int  input_get_raw_bit(FrogButton btn);

--- a/input.h
+++ b/input.h
@@ -47,7 +47,7 @@ bool input_is_pressed(FrogButton btn);
 bool input_was_pressed(FrogButton btn);   /* true only on rising edge this frame */
 bool input_repeat(FrogButton btn);        /* edge, then auto-repeats while held (time-based) */
 
-/* Raw cubevol value (bits 0..16 inclusive, mask 0x1FFFF) needed by remap wizard. (needed by remap wizard). */
+/* Raw cubevol value (bits 0..16 inclusive, mask 0x1FFFF) needed by remap wizard. */
 uint32_t input_get_raw_state(void);
 void input_set_ext_raw(uint32_t raw);
 
@@ -55,6 +55,11 @@ void input_set_ext_raw(uint32_t raw);
 void input_reset_defaults(void);
 void input_set_raw_bit(FrogButton btn, int raw_bit);
 int  input_get_raw_bit(FrogButton btn);
+
+/* True when this device has the physical FN button (R36SX family, detected
+ * via TF_DEVICE; see input.c). Gates the FN default mapping and the FN step
+ * of the mapping wizard. */
+bool input_fn_available(void);
 
 /* Persist/restore keymap file.  Returns 0 on success, -1 on error/not-found. */
 int  input_load_remap(const char *path);


### PR DESCRIPTION
Adds support for the physical FN button present on the R36SX V2.6.

Hardware input mapping confirmed on a physical R36SX V2.6:
- FN = raw bit 16
- FN mask = 0x00010000
- L3 = bit 1
- R3 = bit 2

Changes:
- Extend FrogUI button mapping from 14 to 15 buttons
- Add FN as the final logical/physical mapping entry
- Expand the supported raw input mask to 0x0001FFFF
- Button Mapping wizard now exposes FN as step 15/15
- FN is displayed as "FN"
- B-to-skip behavior remains unchanged
- Existing 14-button keymaps remain compatible
- Existing Apps/FrogShell functionality is unchanged

Validation:
- TreeFrogUI boot: PASS
- Apps visible/preserved: PASS
- FrogShell available: PASS
- Button Mapping total: 15
- FN visible: PASS
- FN physical capture: PASS
- FN displayed as FN: PASS
- FN skip with B: PASS
- Normal UI regression: PASS
- SELECT/START regression: PASS

This implementation was physically validated on TreeFrogUI v1.0.15 Latest
(tag commit 27f3bf33e906d90e0cd267059bf0559afc6f8a05).

The validated FrogUI baseline for that release was:
c0ff79f9383f896b6c324c8c3fd2dedecbf01ac0

No v1.1.x changes were imported.

Related picoarch change:
https://github.com/ozkaoz/TreeFrogUI_picoarch/tree/feature/fn-button-mapping