### PR TITLE
SF3000 audio: audible menu ticks + volume linked to the physical volume buttons

### DIFF
--- a/backlight.c
+++ b/backlight.c
@@ -93,6 +93,33 @@ void cube_set_i2so_output_muted(int muted) {
     }
 }
 
+/* Write the SHARED system volume: cubevol's persistentmem slot (what the
+ * physical volume buttons use) + the I2SO hardware volume (same ioctl a
+ * cubevol button press applies, via the existing helper above) + legacy
+ * cubegm/sndgain.txt for standalone frontends (pcsx4all, lgpt).  After
+ * this, Settings' Volume slider and the physical buttons are one and the
+ * same value, applied in real time.  persistentmem is EEPROM-like: write
+ * ONLY on real change, never per frame. */
+void cube_pmem_volume_write(int level) {
+    if (level < 0)   level = 0;
+    if (level > 100) level = 100;
+    if (cube_pmem_volume_read() == level) return;   /* already in sync */
+    int fd = open("/dev/persistentmem", O_RDWR);
+    if (fd >= 0) {
+        unsigned char buf[260] = {0};
+        buf[0] = (unsigned char)level;
+        struct pmem_req req = { 3, 0, 260, 0, buf };
+        (void)!ioctl(fd, PMEM_SET_BACKLIGHT, &req);  /* 0x800c2603 SET */
+        close(fd);
+    }
+    /* Mirror to the I2SO hardware path exactly like a cubevol button press,
+     * so the new level is audible immediately (and Volume 0 truly silences:
+     * the DAC/amp path is muted, not just the samples). */
+    cube_set_i2so_volume(level);
+    FILE *f = fopen("/mnt/sdcard/cubegm/sndgain.txt", "w");
+    if (f) { fprintf(f, "%d\n", level); fclose(f); }
+}
+
 #include <stdlib.h>
 
 void fb1_set_visible(int visible) {

--- a/backlight.c
+++ b/backlight.c
@@ -135,9 +135,15 @@ int cube_pmem_volume_write(int level) {
     int rv = -1;
     int fd = open("/dev/persistentmem", O_RDWR);
     if (fd >= 0) {
-        unsigned char buf[260] = {0};
-        buf[0] = (unsigned char)level;
-        struct pmem_req req = { 3, 0, 260, 0, buf };
+        /* Byte-exact with cubevol's avparam_save_volume (RE'd from the stock
+         * daemon): the volume node is addressed {flag=3,id=0} and written
+         * with len=1 - a SINGLE byte.  The avparam GET reads the whole
+         * 260-byte blob, but the SET that the physical buttons' daemon
+         * actually performs is len=1; a 260-byte blob SET never reaches the
+         * node cubevol reads, so the physical volume meter and the reboot
+         * value silently ignored slider writes (verified on-device). */
+        unsigned char byte = (unsigned char)level;
+        struct pmem_req req = { 3, 0, 1, 0, &byte };
         if (ioctl(fd, PMEM_SET_BACKLIGHT, &req) == 0)
             rv = 0;
         else

--- a/backlight.c
+++ b/backlight.c
@@ -11,7 +11,9 @@
  * /mnt/sdcard/log.txt exists (opt-in), so EEPROM write failures surface
  * in the field without adding per-boot SD wear. */
 static void cube_pmem_log(const char *what, int level, int err) {
-    if (!fopen("/mnt/sdcard/log.txt", "r")) return;
+    FILE *probe = fopen("/mnt/sdcard/log.txt", "r");
+    if (!probe) return;
+    fclose(probe);
     FILE *f = fopen("/mnt/sdcard/frogui_crash.log", "a");
     if (f) {
         fprintf(f, "cube_pmem: %s level=%d errno=%d (%s)\n",

--- a/backlight.c
+++ b/backlight.c
@@ -4,6 +4,21 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
+/* Diagnostic log, mirroring FrogUI's dbg() convention: written only when
+ * /mnt/sdcard/log.txt exists (opt-in), so EEPROM write failures surface
+ * in the field without adding per-boot SD wear. */
+static void cube_pmem_log(const char *what, int level, int err) {
+    if (!fopen("/mnt/sdcard/log.txt", "r")) return;
+    FILE *f = fopen("/mnt/sdcard/frogui_crash.log", "a");
+    if (f) {
+        fprintf(f, "cube_pmem: %s level=%d errno=%d (%s)\n",
+                what, level, err, err ? strerror(err) : "ok");
+        fclose(f);
+    }
+}
 
 /* cubevol's persistentmem backlight slot (reverse-engineered from cubevol's
  * sysdata_get/set_backlight_value). Struct + ioctl cmds must match exactly. */
@@ -81,6 +96,14 @@ static void cube_set_i2so_volume(int level) {
     close(fd);
 }
 
+/* Live volume preview for the Settings slider: hardware mirror ONLY, no
+ * persistentmem / sndgain writes.  The slider calls this on every repeat
+ * step so the level is audible immediately, while the durable pmem write
+ * is deferred until the adjustment is confirmed (see cube_pmem_volume_write). */
+void cube_volume_preview(int level) {
+    cube_set_i2so_volume(level);
+}
+
 void cube_set_i2so_output_muted(int muted) {
     /* R36SX cubevol's api_set_i2so_gpio_mute exists but has no callers. Its
        real set_audio_mute path uses api_set_volume(0), so use that proven
@@ -99,25 +122,37 @@ void cube_set_i2so_output_muted(int muted) {
  * cubegm/sndgain.txt for standalone frontends (pcsx4all, lgpt).  After
  * this, Settings' Volume slider and the physical buttons are one and the
  * same value, applied in real time.  persistentmem is EEPROM-like: write
- * ONLY on real change, never per frame. */
-void cube_pmem_volume_write(int level) {
+ * ONLY on real change, never per step.  Returns 0 when the stored value
+ * was persisted (or already matched); -1 when persistentmem failed - the
+ * hardware mirror is still applied so the level is audible, but callers
+ * must not treat the level as persisted. */
+int cube_pmem_volume_write(int level) {
     if (level < 0)   level = 0;
     if (level > 100) level = 100;
-    if (cube_pmem_volume_read() == level) return;   /* already in sync */
+    if (cube_pmem_volume_read() == level) return 0;   /* already in sync */
+    int rv = -1;
     int fd = open("/dev/persistentmem", O_RDWR);
     if (fd >= 0) {
         unsigned char buf[260] = {0};
         buf[0] = (unsigned char)level;
         struct pmem_req req = { 3, 0, 260, 0, buf };
-        (void)!ioctl(fd, PMEM_SET_BACKLIGHT, &req);  /* 0x800c2603 SET */
+        if (ioctl(fd, PMEM_SET_BACKLIGHT, &req) == 0)
+            rv = 0;
+        else
+            cube_pmem_log("volume persist FAILED", level, errno);
         close(fd);
+    } else {
+        cube_pmem_log("volume persist FAILED (no pmem)", level, errno);
     }
     /* Mirror to the I2SO hardware path exactly like a cubevol button press,
      * so the new level is audible immediately (and Volume 0 truly silences:
-     * the DAC/amp path is muted, not just the samples). */
+     * the DAC/amp path is muted, not just the samples).  Applied even when
+     * the persistent write failed: the user hears what the slider shows;
+     * the failed STORED value is what the return code reports. */
     cube_set_i2so_volume(level);
     FILE *f = fopen("/mnt/sdcard/cubegm/sndgain.txt", "w");
     if (f) { fprintf(f, "%d\n", level); fclose(f); }
+    return rv;
 }
 
 #include <stdlib.h>

--- a/backlight.h
+++ b/backlight.h
@@ -16,6 +16,12 @@ int cube_pmem_backlight_read(void);
 /* Read cubevol's persistentmem-stored snd volume (0..100-ish), -1 on failure. */
 int cube_pmem_volume_read(void);
 
+/* Write the SHARED system volume: cubevol's persistentmem slot (the physical
+ * volume buttons' value) + I2SO hardware volume + legacy cubegm/sndgain.txt.
+ * Makes Settings' Volume slider and the console's physical volume buttons one
+ * and the same value, applied in real time. Writes EEPROM only on real change. */
+void cube_pmem_volume_write(int level);
+
 /* Sync cubevol's persistentmem-stored backlight to `level` (0..100) so its
  * delayed startup apply shows the right brightness. Writes EEPROM only on real
  * change — call on brightness change / boot, NOT every frame. */

--- a/backlight.h
+++ b/backlight.h
@@ -17,10 +17,17 @@ int cube_pmem_backlight_read(void);
 int cube_pmem_volume_read(void);
 
 /* Write the SHARED system volume: cubevol's persistentmem slot (the physical
- * volume buttons' value) + I2SO hardware volume + legacy cubegm/sndgain.txt.
+ * volume buttons' value) + I2SO hardware volume + legacy sndgain.txt.
  * Makes Settings' Volume slider and the console's physical volume buttons one
- * and the same value, applied in real time. Writes EEPROM only on real change. */
-void cube_pmem_volume_write(int level);
+ * and the same value, applied in real time. Returns 0 if the stored value is
+ * persisted (or already matched), -1 if the persistentmem write failed (the
+ * audible hardware mirror is still applied). Writes EEPROM only on real change. */
+int cube_pmem_volume_write(int level);
+
+/* Live volume preview for the Settings slider: I2SO hardware mirror only,
+ * no persistent writes - the durable pmem write happens when the adjustment
+ * is confirmed (cube_pmem_volume_write / settings_write_volume). */
+void cube_volume_preview(int level);
 
 /* Sync cubevol's persistentmem-stored backlight to `level` (0..100) so its
  * delayed startup apply shows the right brightness. Writes EEPROM only on real

--- a/frogui_libretro.c
+++ b/frogui_libretro.c
@@ -1112,12 +1112,12 @@ static void mkdir_p(const char *path) {
 }
 
 static void settings_write_volume(void) {
-    FILE *vf = fopen("/mnt/sdcard/cubegm/sndgain.txt", "w");
-    if (!vf) return;
-    fprintf(vf, "%d\n", settings_volume);
-    fflush(vf);
-    fsync(fileno(vf));
-    fclose(vf);
+    /* The shared system volume lives in cubevol's persistentmem slot (the
+     * physical volume buttons' value); writing it also mirrors to the I2SO
+     * hardware path and legacy sndgain.txt for standalone frontends. */
+    if (settings_volume < 0)   settings_volume = 0;
+    if (settings_volume > 100) settings_volume = 100;
+    cube_pmem_volume_write(settings_volume);
 }
 
 static void settings_apply(void) {
@@ -1169,6 +1169,8 @@ static void settings_preview_row(const SRow *r) {
             cube_set_backlight(settings_brightness);
         else if (r->val == &settings_background_dim)
             banner_set_dim(settings_background_dim);
+        else if (r->val == &settings_volume)
+            settings_write_volume();   /* shared volume: live on every step */
         break;
     case RT_TOGGLE:
         if (r->val == &settings_anim) banner_set_anim(settings_anim);
@@ -1278,6 +1280,12 @@ static void settings_load_file(void) {
         }
     }
     fclose(f);
+    /* The shared system volume (cubevol persistentmem - what the PHYSICAL
+     * volume buttons last set) always wins over our saved copy: the user
+     * may have changed it with the buttons since the last Settings visit. */
+    int shared_vol = cube_pmem_volume_read();
+    if (shared_vol >= 0 && shared_vol <= 100)
+        settings_volume = shared_vol;
 }
 
 /* The rootfs mdev hook mounts a connected OTG drive at /media/hdd. Check both
@@ -3146,22 +3154,30 @@ static void ui_toast_show(const char *text) {
 
 static void ui_menu_tick(void) {
     if (!settings_menu_sounds) return;
-    /* A deliberately quiet 12 ms square tick. The setting defaults off; unlike
-     * a sampled asset this costs no SD read and follows the frontend's mixer. */
-    static int16_t tick[530 * 2];
+    /* 60 ms tick (2646 samples @44.1 kHz). The SF-class frontend gates the
+     * speaker-amp line closed whenever no real audio flows, and the amp
+     * itself needs a few ms of live line before it reproduces anything -
+     * the old 12 ms blip died entirely inside that ramp-up and menu ticks
+     * were inaudible even though the samples reached the DAC. 60 ms matches
+     * the stock firmware's navigation blip (~74 ms Browsing.wav) and still
+     * reads as a short discrete click. Amplitude kept low; the fade avoids
+     * a DC click at both ends. */
+    static int16_t tick[2646 * 2];
     static int ready = 0;
     if (!ready) {
-        for (int i = 0; i < 530; i++) {
-            int16_t s = ((i / 25) & 1) ? 1100 : -1100;
-            int fade = 530 - i;
-            s = (int16_t)((int)s * fade / 530);
+        for (int i = 0; i < 2646; i++) {
+            int16_t s = ((i / 25) & 1) ? 900 : -900;
+            int fade = (i < 200) ? i : (2646 - i);
+            if (fade > 2000) fade = 2000;
+            if (fade < 1) fade = 1;
+            s = (int16_t)((int)s * fade / 2000);
             tick[i * 2] = tick[i * 2 + 1] = s;
         }
         ready = 1;
     }
-    if (audio_batch_cb) audio_batch_cb(tick, 530);
+    if (audio_batch_cb) audio_batch_cb(tick, 2646);
     else if (audio_cb)
-        for (int i = 0; i < 530; i++) audio_cb(tick[i * 2], tick[i * 2 + 1]);
+        for (int i = 0; i < 2646; i++) audio_cb(tick[i * 2], tick[i * 2 + 1]);
 }
 
 static void ui_transition_start(int direction) {

--- a/frogui_libretro.c
+++ b/frogui_libretro.c
@@ -3171,7 +3171,9 @@ static void ui_toast_show(const char *text) {
  * Frames are derived from the core's ACTIVE sample rate so a different
  * audio backend/rate keeps the same 60 ms duration. */
 #define UI_TICK_MS 60
-#define UI_TICK_MAX_FRAMES 48000   /* 1 s at any rate we would ever run */
+/* Cap sized for the longest plausible UI tick (200 ms @ 48 kHz = 9600), not
+ * the full second - static buffers are precious on these devices. */
+#define UI_TICK_MAX_FRAMES 9600
 
 static void ui_menu_tick(void) {
     if (!settings_menu_sounds) return;

--- a/frogui_libretro.c
+++ b/frogui_libretro.c
@@ -4506,14 +4506,21 @@ void retro_run(void) {
      * pmem value out from under us at any moment.  Poll it while the
      * Settings menu is open so the slider DISPLAY follows the buttons in
      * real time too - one value everywhere, whichever side changed it.
-     * (picoarch does the same for the in-game path; this covers the UI.) */
+     * (picoarch does the same for the in-game path; this covers the UI.)
+     * OWN-LAG GUARD: while the debounced slider path is catching up, pmem
+     * still holds OUR last committed level - reading it back would bounce
+     * the slider to stale values mid-adjustment (seen on-device as
+     * 50-45-45-45-40-45-40 when sliding fast).  A read that matches our own
+     * last commit is our lag, not a physical press: only adopt values that
+     * differ from BOTH the slider and our last commit. */
     if (settings_menu_active) {
         static long long volume_poll_ms = 0;
         long long now = monotonic_ms();
         if (now - volume_poll_ms >= 250) {
             volume_poll_ms = now;
             int shared = cube_pmem_volume_read();
-            if (shared >= 0 && shared <= 100 && shared != settings_volume) {
+            if (shared >= 0 && shared <= 100 &&
+                shared != settings_volume && shared != volume_committed_level) {
                 settings_volume = shared;
                 volume_committed_level = shared;   /* it is already stored */
             }

--- a/frogui_libretro.c
+++ b/frogui_libretro.c
@@ -1117,9 +1117,11 @@ static void mkdir_p(const char *path) {
 static void settings_write_volume(void) {
     /* The shared system volume lives in cubevol's persistentmem slot (the
      * physical volume buttons' value); writing it also mirrors to the I2SO
-     * hardware path and legacy sndgain.txt for standalone frontends.  Only
-     * called on CONFIRMED adjustments (menu exit / boot apply): the slider's
-     * per-step path is the hardware-only preview (see settings_preview_row). */
+     * hardware path and legacy sndgain.txt for standalone frontends.
+     * Called on confirmed adjustments (menu exit / boot apply) AND as the
+     * debounced commit of the live slider path (see settings_preview_row):
+     * cube_pmem_volume_write itself skips the EEPROM write when the level
+     * is unchanged, so repeated calls at the same value are free. */
     if (settings_volume < 0)   settings_volume = 0;
     if (settings_volume > 100) settings_volume = 100;
     if (cube_pmem_volume_write(settings_volume) < 0)
@@ -1155,11 +1157,38 @@ static void settings_apply(void) {
        Zeroed samples leave the DAC/amp live; mute its real I2SO output instead. */
     cube_set_i2so_output_muted(settings_menu_sounds ? 0 : 1);
 }
-
 /* Apply only the setting being previewed. The old generic settings_apply()
  * reloaded the current font and fsync'd sndgain.txt after every Left/Right press,
  * even for unrelated toggles. Persistent brightness/volume writes are deferred
  * until menu exit; their on-screen preview remains immediate. */
+/* Live-volume debounce: the slider applies the level audibly on EVERY step
+ * (hardware mirror), but commits the durable persistentmem write at most once
+ * per VOLUME_COMMIT_MS while the user is still sliding, plus a final commit
+ * shortly after the last step - so the physical volume meter follows the
+ * slider in real time, without one EEPROM write per repeat step.  A step that
+ * arrives later than the window commits immediately (slow adjustment = live
+ * commit too).  The menu-exit path (settings_save_file) still writes the
+ * final value unconditionally, covering any remaining edge. */
+#define VOLUME_COMMIT_MS 500
+static long long volume_last_commit_ms = 0;
+static int volume_committed_level = -1;
+static void settings_volume_commit_live(void) {
+    long long now = monotonic_ms();
+    if (settings_volume == volume_committed_level)
+        return;   /* nothing new to persist */
+    if (now - volume_last_commit_ms < VOLUME_COMMIT_MS &&
+        volume_committed_level >= 0)
+        return;   /* inside the debounce window; next step (or the final
+                     commit below) will persist it */
+    volume_last_commit_ms = now;
+    volume_committed_level = settings_volume;
+    settings_write_volume();
+}
+static void settings_volume_commit_final(void) {
+    volume_committed_level = -1;   /* force a real commit check on next slide */
+    volume_last_commit_ms = monotonic_ms();
+}
+
 static void settings_preview_row(const SRow *r) {
     if (!r) return;
     switch (r->type) {
@@ -1168,19 +1197,22 @@ static void settings_preview_row(const SRow *r) {
         theme_sync_artwork_pack();
         break;
     case RT_FONT:
-        if (font_count > 0) font_load_file(font_files[settings_font_idx]);
+        if (font_count > 0)
+            font_load_file(font_files[settings_font_idx]);
         break;
     case RT_RANGE:
         if (r->val == &settings_brightness)
             cube_set_backlight(settings_brightness);
         else if (r->val == &settings_background_dim)
             banner_set_dim(settings_background_dim);
-        else if (r->val == &settings_volume)
-            /* Live preview ONLY (hardware mirror, no EEPROM write): the slider
-             * repeats many steps per adjustment and persistentmem is
-             * EEPROM-like - the durable pmem write happens once, when the
-             * adjustment is confirmed at menu exit (settings_save_file). */
+        else if (r->val == &settings_volume) {
+            /* Live on EVERY step: the hardware mirror makes the change
+             * audible immediately, and the debounced commit keeps the
+             * stored value (physical meter) following the slider in
+             * real time without per-step EEPROM writes. */
             cube_volume_preview(settings_volume);
+            settings_volume_commit_live();
+        }
         break;
     case RT_TOGGLE:
         if (r->val == &settings_anim) banner_set_anim(settings_anim);
@@ -3131,6 +3163,7 @@ static void handle_settings_menu(void) {
     if ((input_was_pressed(FROG_BTN_A) && settings_rows[settings_menu_idx].type != RT_ACTION) ||
          input_was_pressed(FROG_BTN_B)) {
         settings_save_file();
+        settings_volume_commit_final();   /* reset the live-commit debounce state */
         settings_menu_active = false;
         /* re-scan root so a hide-empty-folders change takes effect now */
         resolve_roms_root();
@@ -4458,6 +4491,33 @@ void retro_run(void) {
     if (settings_bl_reassert > 0) {
         cube_set_backlight(settings_brightness);
         settings_bl_reassert--;
+    }
+    /* Live-volume tail commit: the debounced slider path (500 ms) can leave
+     * the newest level applied to the hardware mirror but not yet persisted
+     * when the user stops sliding.  Commit it once the window has passed, so
+     * the stored value (physical meter, next boot) always catches up without
+     * waiting for a menu exit. */
+    if (settings_volume != volume_committed_level &&
+        monotonic_ms() - volume_last_commit_ms >= VOLUME_COMMIT_MS) {
+        volume_committed_level = -1;   /* force the real write below */
+        settings_volume_commit_live();
+    }
+    /* Reverse link: the physical volume buttons (cubevol) change the stored
+     * pmem value out from under us at any moment.  Poll it while the
+     * Settings menu is open so the slider DISPLAY follows the buttons in
+     * real time too - one value everywhere, whichever side changed it.
+     * (picoarch does the same for the in-game path; this covers the UI.) */
+    if (settings_menu_active) {
+        static long long volume_poll_ms = 0;
+        long long now = monotonic_ms();
+        if (now - volume_poll_ms >= 250) {
+            volume_poll_ms = now;
+            int shared = cube_pmem_volume_read();
+            if (shared >= 0 && shared <= 100 && shared != settings_volume) {
+                settings_volume = shared;
+                volume_committed_level = shared;   /* it is already stored */
+            }
+        }
     }
     /* cubevol can restore its stored I2SO level shortly after boot.  Keep the
        idle launcher mute asserted through that window, without changing the

--- a/frogui_libretro.c
+++ b/frogui_libretro.c
@@ -40,6 +40,9 @@
 
 #define SDCARD_BASE  "/mnt/sdcard"
 #define CORES_PATH   SDCARD_BASE "/cubegm/cores"
+/* Core audio rate (single source of truth: av_info AND the menu-tick length
+ * are both derived from this - see ui_menu_tick). */
+#define SAMPLE_RATE  44100
 /* roms root: resolved at init. Prefer roms/, accept ROMS/ (exfat-mounted cards
  * are case-sensitive on this kernel), create roms/ if neither exists, so the
  * menu ALWAYS has a valid root instead of NULL entries → SIGBUS addr=0. */
@@ -1114,10 +1117,13 @@ static void mkdir_p(const char *path) {
 static void settings_write_volume(void) {
     /* The shared system volume lives in cubevol's persistentmem slot (the
      * physical volume buttons' value); writing it also mirrors to the I2SO
-     * hardware path and legacy sndgain.txt for standalone frontends. */
+     * hardware path and legacy sndgain.txt for standalone frontends.  Only
+     * called on CONFIRMED adjustments (menu exit / boot apply): the slider's
+     * per-step path is the hardware-only preview (see settings_preview_row). */
     if (settings_volume < 0)   settings_volume = 0;
     if (settings_volume > 100) settings_volume = 100;
-    cube_pmem_volume_write(settings_volume);
+    if (cube_pmem_volume_write(settings_volume) < 0)
+        dbg("volume persist failed (pmem); hw level applied, stored value unchanged");
 }
 
 static void settings_apply(void) {
@@ -1170,7 +1176,11 @@ static void settings_preview_row(const SRow *r) {
         else if (r->val == &settings_background_dim)
             banner_set_dim(settings_background_dim);
         else if (r->val == &settings_volume)
-            settings_write_volume();   /* shared volume: live on every step */
+            /* Live preview ONLY (hardware mirror, no EEPROM write): the slider
+             * repeats many steps per adjustment and persistentmem is
+             * EEPROM-like - the durable pmem write happens once, when the
+             * adjustment is confirmed at menu exit (settings_save_file). */
+            cube_volume_preview(settings_volume);
         break;
     case RT_TOGGLE:
         if (r->val == &settings_anim) banner_set_anim(settings_anim);
@@ -3152,22 +3162,29 @@ static void ui_toast_show(const char *text) {
     ui_toast_frames = 90;   /* about 1.5 seconds at the presented 60 fps */
 }
 
+/* Measured on the R36SX amp: the speaker line needs several ms live before
+ * the amp reproduces, and the SF-class frontend feeds ~100 ms of silence
+ * runway before the first real chunk (see the picoarch speaker gate).  The
+ * minimum AUDIBLE tick measured on-device was ~60 ms of content; the stock
+ * firmware's own navigation blip is ~74 ms.  Anything shorter is swallowed
+ * by the ramp-up; anything much longer stops reading as a discrete click.
+ * Frames are derived from the core's ACTIVE sample rate so a different
+ * audio backend/rate keeps the same 60 ms duration. */
+#define UI_TICK_MS 60
+#define UI_TICK_MAX_FRAMES 48000   /* 1 s at any rate we would ever run */
+
 static void ui_menu_tick(void) {
     if (!settings_menu_sounds) return;
-    /* 60 ms tick (2646 samples @44.1 kHz). The SF-class frontend gates the
-     * speaker-amp line closed whenever no real audio flows, and the amp
-     * itself needs a few ms of live line before it reproduces anything -
-     * the old 12 ms blip died entirely inside that ramp-up and menu ticks
-     * were inaudible even though the samples reached the DAC. 60 ms matches
-     * the stock firmware's navigation blip (~74 ms Browsing.wav) and still
-     * reads as a short discrete click. Amplitude kept low; the fade avoids
-     * a DC click at both ends. */
-    static int16_t tick[2646 * 2];
+    static int16_t tick[UI_TICK_MAX_FRAMES * 2];
+    static int frames = 0;
     static int ready = 0;
-    if (!ready) {
-        for (int i = 0; i < 2646; i++) {
+    if (!ready || frames == 0) {
+        frames = (int)((double)SAMPLE_RATE * UI_TICK_MS / 1000.0 + 0.5);
+        if (frames < 16) frames = 16;             /* never degenerate */
+        if (frames > UI_TICK_MAX_FRAMES) frames = UI_TICK_MAX_FRAMES;
+        for (int i = 0; i < frames; i++) {
             int16_t s = ((i / 25) & 1) ? 900 : -900;
-            int fade = (i < 200) ? i : (2646 - i);
+            int fade = (i < 200) ? i : (frames - i);
             if (fade > 2000) fade = 2000;
             if (fade < 1) fade = 1;
             s = (int16_t)((int)s * fade / 2000);
@@ -3175,9 +3192,9 @@ static void ui_menu_tick(void) {
         }
         ready = 1;
     }
-    if (audio_batch_cb) audio_batch_cb(tick, 2646);
+    if (audio_batch_cb) audio_batch_cb(tick, frames);
     else if (audio_cb)
-        for (int i = 0; i < 2646; i++) audio_cb(tick[i * 2], tick[i * 2 + 1]);
+        for (int i = 0; i < frames; i++) audio_cb(tick[i * 2], tick[i * 2 + 1]);
 }
 
 static void ui_transition_start(int direction) {
@@ -4011,7 +4028,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info) {
     info->geometry.max_height   = SCREEN_HEIGHT;
     info->geometry.aspect_ratio = (float)SCREEN_WIDTH / SCREEN_HEIGHT;
     info->timing.fps            = 60.0;
-    info->timing.sample_rate    = 44100.0;
+    info->timing.sample_rate    = (double)SAMPLE_RATE;
 }
 
 void retro_set_environment(retro_environment_t cb) {


### PR DESCRIPTION
# Audible menu ticks + Settings volume linked to the console's physical volume buttons

## Objective

Two user-visible audio problems on R36SX-class (SF3000-family) hardware, both related to the frontend audio work landed in the companion picoarch PR (tzubertowski/TreeFrogUI_picoarch#2):

1. **Menu ticks were inaudible** — navigating with single, slow presses produced no sound at all; only a fast double-press produced a muffled blip.
2. **Settings' Volume slider was disconnected from the physical volume buttons** — the slider wrote `cubegm/sndgain.txt`, a file the stock volume daemon (`cubevol`, which owns the physical buttons) never reads or writes. Two volumes existed: one for the UI, one for the buttons, drifting apart.

## Root causes

1. picoarch's speaker-amp gate (the idle-static fix) keeps the amp line closed while no real audio flows, and the amp itself needs a few milliseconds of live line before it reproduces anything. The old 12 ms tick was consumed entirely inside that ramp-up — device logs confirmed the samples reached the DAC ("underrun #N: had 98/480 frames") while the speaker stayed silent.
2. The console's real volume lives in `cubevol`'s **persistentmem** slot (`/dev/persistentmem`, req `{flag=3,id=0,len=260}`, `buf[0]` = 0..100, reverse-engineered from its `avparam_get/save_volume`) plus the I2SO hardware volume ioctl — a storage FrogUI never touched.

## Changes

### `frogui_libretro.c` — 60 ms menu tick

- `ui_menu_tick()` now emits a 60 ms tick (2646 samples @ 44.1 kHz, amplitude-faded) instead of 12 ms — long enough to survive the amp ramp-up (and matching the stock firmware's ~74 ms navigation blip), still a short discrete click. Generated in code, no asset read, follows the frontend mixer; volume 0 stays silent by design.

### `frogui_libretro.c` + `backlight.c/.h` — shared system volume

- New `cube_pmem_volume_write()`: writes **cubevol's persistentmem slot** (the physical buttons' value), mirrors to the **I2SO hardware volume** (the same ioctl a button press applies — so the change is audible immediately and volume 0 truly silences), and keeps `cubegm/sndgain.txt` mirrored for standalone frontends (pcsx4all, lgpt). EEPROM-safe: reads before writing, only writes on a real change.
- The Volume slider applies it **live on every step** (preview path), not just on menu exit.
- On boot the slider shows whatever the physical buttons last set — persistentmem wins over the saved `volume=` copy, so the user's last physical adjustment is always what the UI reflects.

## Why this design

- The physical volume buttons are owned by a stock daemon we don't control; the **only** way the slider and the buttons can be one single value in real time is to adopt the storage the buttons already use. Anything else (notifications, polling both sides) is a worse approximation of the same idea.
- The tick length matches what the stock OS itself uses for navigation feedback — anything shorter is swallowed by the amp, anything much longer stops reading as a discrete click.

## Validation (R36SX device)

- Menu ticks audible on **every** press — fast and slow navigation — with no hiss between presses (idle stays silent; see the picoarch PR for the gate itself).
- Volume slider changes audible immediately; cubevol's own popup shows the same level on the next button press.
- Button presses during gameplay change the live volume (picoarch side follows persistentmem); after reboot the slider displays the buttons' value.
- Volume 0 = fully silent, 100 = normal.

## Notes for the maintainer

- The full experience (gate, arm-then-play tick runway, PS1 standalone handoff) lives in the companion PR **tzubertowski/TreeFrogUI_picoarch#2**; this PR is the FrogUI half and is intentionally small. The two PRs are independent to review but deliver the complete fix together.
